### PR TITLE
Normalize return type of the API methods

### DIFF
--- a/lib/outbound.rb
+++ b/lib/outbound.rb
@@ -332,7 +332,7 @@ module Outbound
         err = "#{status}"
         err << " - #{res.body}" unless res.body.empty?
       end
-      return err, true
+      return Result.new err, true
     end
 
     def user(info={})


### PR DESCRIPTION
When calling the public API interface the return types of the various methods changes depending on success/failure or invalid parameters.

If the remote API call succeeds then [nil, true] is returned. If the remote API call fails then something like [500, true] is returned(or a different status code), but in all other cases you get the Result object back.

I believe the correct thing to do is always return the results of the API calls in a Result object. 