### PR TITLE
Remove debug `puts` from Outbound::Client#track

### DIFF
--- a/lib/outbound.rb
+++ b/lib/outbound.rb
@@ -217,7 +217,6 @@ module Outbound
       end
 
       data[:timestamp] = timestamp
-      puts timestamp
 
       post(@api_key, '/track', data)
     end


### PR DESCRIPTION
Hi!

You missed the debug output into `Outbound::Client#track`.